### PR TITLE
Fix/some issues

### DIFF
--- a/node/src/style/style.scss
+++ b/node/src/style/style.scss
@@ -448,12 +448,12 @@ body {
             color: #444;
             pointer-events: auto;
             text-align: right;
-        
+
+            -moz-appearance:textfield;
             &::-webkit-inner-spin-button,
             &::-webkit-outer-spin-button {
               -webkit-appearance: none;
               margin: 0;
-              -moz-appearance:textfield;
             }
           }
         }

--- a/node/src/ts/visualizer/index.tsx
+++ b/node/src/ts/visualizer/index.tsx
@@ -133,10 +133,6 @@ const selector = ({ filter: { lowerLimitOfClassEntities } }: RootState) => ({
 
 const App: React.FC<AppProps> = (props) => {
   const { content } = props
-  const [locale, setLocale] = useState('ja')
-  const [messages, setMessages] = useState<{ [key: string]: string }>(
-    getLocaleMessages('ja')
-  )
   const dispatch = useDispatch()
   const query = useQuery()
   const history = useHistory()
@@ -170,11 +166,6 @@ const App: React.FC<AppProps> = (props) => {
     if (isEmptyContent(preferredContent) || !isEmptyContent(rawState)) {
       return
     }
-
-    // set locale/messages
-    const localeShortString = getLocaleShortString()
-    setLocale(localeShortString)
-    setMessages(getLocaleMessages(localeShortString))
 
     const entitiesLowerLimit = Number(query.get('lower_limit'))
     if (Number.isInteger(entitiesLowerLimit)) {
@@ -248,20 +239,16 @@ const App: React.FC<AppProps> = (props) => {
   }, [rawState, lowerLimitOfClassEntities])
 
   return (
-    <IntlProvider locale={locale} messages={messages}>
-      <>
-        <div id="main">
-          <PropertyList properties={state.properties} />
-          <Graph classes={state.classes} structure={state.structure} />
-          <Detail classes={state.classes} getReferenceURL={getReferenceURL} />
-          <div id="header-right">
-            <SearchBox classes={state.classes} />
-            <Prefix prefixes={state.prefixes} />
-          </div>
-          <Tooltip classes={state.classes} />
-        </div>
-      </>
-    </IntlProvider>
+    <div id="main">
+      <PropertyList properties={state.properties} />
+      <Graph classes={state.classes} structure={state.structure} />
+      <Detail classes={state.classes} getReferenceURL={getReferenceURL} />
+      <div id="header-right">
+        <SearchBox classes={state.classes} />
+        <Prefix prefixes={state.prefixes} />
+      </div>
+      <Tooltip classes={state.classes} />
+    </div>
   )
 }
 
@@ -270,15 +257,29 @@ App.displayName = 'App'
 const store = configureStore()
 const Visualizer: React.FC<AppProps> = (props) => {
   const { content } = props
+  const [locale, setLocale] = useState('en')
+  const [messages, setMessages] = useState<{ [key: string]: string }>(
+    getLocaleMessages('en')
+  )
   const footer = useDBCLSFooterOuterText()
+
+  useEffect(() => {
+    const localeShortString = getLocaleShortString()
+    setLocale(localeShortString)
+    setMessages(getLocaleMessages(localeShortString))
+  }, [])
+
   const footerElement = useMemo(() => {
     // eslint-disable-next-line react/no-danger
     return <div dangerouslySetInnerHTML={{ __html: footer }} />
   }, [footer])
+
   return (
     <ReduxProvider store={store}>
-      <App content={content} />
-      {footerElement}
+      <IntlProvider locale={locale} messages={messages}>
+        <App content={content} />
+        {footerElement}
+      </IntlProvider>
     </ReduxProvider>
   )
 }

--- a/node/src/ts/visualizer/index.tsx
+++ b/node/src/ts/visualizer/index.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable camelcase */
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { IntlProvider } from 'react-intl'
 
 import '@formatjs/intl-pluralrules/polyfill'
@@ -137,7 +137,6 @@ const App: React.FC<AppProps> = (props) => {
   const [messages, setMessages] = useState<{ [key: string]: string }>(
     getLocaleMessages('ja')
   )
-  const footer = useDBCLSFooterOuterText()
   const dispatch = useDispatch()
   const query = useQuery()
   const history = useHistory()
@@ -261,10 +260,6 @@ const App: React.FC<AppProps> = (props) => {
           </div>
           <Tooltip classes={state.classes} />
         </div>
-        <div
-          // eslint-disable-next-line react/no-danger
-          dangerouslySetInnerHTML={{ __html: footer }}
-        />
       </>
     </IntlProvider>
   )
@@ -275,9 +270,15 @@ App.displayName = 'App'
 const store = configureStore()
 const Visualizer: React.FC<AppProps> = (props) => {
   const { content } = props
+  const footer = useDBCLSFooterOuterText()
+  const footerElement = useMemo(() => {
+    // eslint-disable-next-line react/no-danger
+    return <div dangerouslySetInnerHTML={{ __html: footer }} />
+  }, [footer])
   return (
     <ReduxProvider store={store}>
       <App content={content} />
+      {footerElement}
     </ReduxProvider>
   )
 }

--- a/node/src/ts/visualizer/utils/index.ts
+++ b/node/src/ts/visualizer/utils/index.ts
@@ -22,7 +22,7 @@ export const getLocaleShortString = (): string => {
     window.navigator.language ||
     window.navigator.userLanguage ||
     window.navigator.browserLanguage ||
-    'ja' // default
+    'en'
   const locale = language.substring(0, 2)
 
   return locale


### PR DESCRIPTION
Fix position to declare footer in Visualizer - 5e3741b
フッタの呼び出し位置を修正、メモ化

Fix position to set locale in Visualizer - 5229176
下記2点を修正
* IntelProviderの設定周りを上位コンポーネントへ移動
(重いコンテンツを表示する際にデータを受信するまで翻訳がされない作りになっていたため)
* デフォルトのロケールを'ja'→'en'に修正
(他ページはデフォルトで'en'を使用しているため、統一)

Hide spin button from input field - 1650127
Firefox上で<input type="number">のスピンボタンが消えていなかったので、削除