### PR TITLE
Fix/some issues

### DIFF
--- a/node/src/style/style.scss
+++ b/node/src/style/style.scss
@@ -414,13 +414,13 @@ body {
       }
 
       #filter-wrapper {
-        width: 376px;
         top: calc(#{$header-height} + 8px);
         right: calc(332px + 16px);
         position: fixed;
         z-index: 5;
 
         #filter {
+          width: 376px;
           background-color: rgba(255, 255, 255, 0.8);
           border: 1px solid #dddee2;
           padding: 16px 8px 8px 16px;

--- a/node/src/style/style.scss
+++ b/node/src/style/style.scss
@@ -1064,6 +1064,7 @@ body {
             text-decoration: underline;
             color: #a567a7;
             cursor: pointer;
+            text-align: left;
           }
         }
       }

--- a/node/src/ts/visualizer/components/ClassRelationsDetail.tsx
+++ b/node/src/ts/visualizer/components/ClassRelationsDetail.tsx
@@ -2,12 +2,13 @@ import React, { useCallback, useMemo } from 'react'
 import { useIntl } from 'react-intl'
 import { useDispatch } from 'react-redux'
 import { DetailAction } from '../actions/detail'
-import { ClassDetail } from '../types/class'
+import { Classes } from '../types/class'
+import { getPreferredLabel } from '../utils'
 import GraphRepository from '../utils/GraphRepository'
 
 type ClassRelationsDetailProps = {
   title: string
-  classDetail: ClassDetail
+  classes: Classes
   fromPropertySelection?: boolean
   focusingURI: string | null
   showLeftHand: boolean
@@ -17,7 +18,7 @@ type ClassRelationsDetailProps = {
 const ClassRelationsDetail: React.FC<ClassRelationsDetailProps> = (props) => {
   const {
     title,
-    classDetail,
+    classes,
     fromPropertySelection,
     focusingURI,
     showLeftHand,
@@ -25,6 +26,23 @@ const ClassRelationsDetail: React.FC<ClassRelationsDetailProps> = (props) => {
   } = props
   const dispatch = useDispatch()
   const intl = useIntl()
+  const classDetail = useMemo(() => classes[focusingURI || ''], [
+    classes,
+    focusingURI,
+  ])
+
+  const getPreferredTriple = useCallback(
+    (triple: string[]) => {
+      if (triple.length < 3) {
+        return '<><><>'
+      }
+      const subject = getPreferredLabel(triple[0], classes, intl.locale)
+      const predicate = getPreferredLabel(triple[1], classes, intl.locale)
+      const object = getPreferredLabel(triple[2], classes, intl.locale)
+      return `<${subject}><${predicate}><${object}>`
+    },
+    [classes, intl.locale]
+  )
 
   const focusPropertyClass = useCallback(() => {
     const target = GraphRepository.findUriNode(focusingURI)
@@ -100,17 +118,22 @@ const ClassRelationsDetail: React.FC<ClassRelationsDetailProps> = (props) => {
                 e.preventDefault()
                 dispatch(DetailAction.showRelation(rhs))
               }
+              const triple = [focusingURI || '', rhs[0], rhs[1]]
               return (
                 <li key={`component-classrelationdetail-list-rhs-${index}`}>
-                  <button type="button" onClick={relationClass}>
+                  <button
+                    type="button"
+                    title={getPreferredTriple(triple)}
+                    onClick={relationClass}
+                  >
                     <span className="focusing">
-                      {`<${focusingURI}>`}
+                      {`<${triple[0]}>`}
                       &nbsp;
                     </span>
-                    <span>{`<${rhs[0]}>`}</span>
+                    <span>{`<${triple[1]}>`}</span>
                     <span className="object">
                       &nbsp;
-                      {`<${rhs[1]}>`}
+                      {`<${triple[2]}>`}
                     </span>
                     &nbsp;.
                   </button>
@@ -128,6 +151,7 @@ const ClassRelationsDetail: React.FC<ClassRelationsDetailProps> = (props) => {
       handleClickRightHandSideClasses,
       intl,
       showRightHand,
+      getPreferredTriple,
     ]
   )
 
@@ -151,17 +175,22 @@ const ClassRelationsDetail: React.FC<ClassRelationsDetailProps> = (props) => {
                 e.preventDefault()
                 dispatch(DetailAction.showRelation(lhs))
               }
+              const triple = [lhs[0], lhs[1], focusingURI || '']
               return (
                 <li key={index}>
-                  <button type="button" onClick={relationClass}>
+                  <button
+                    type="button"
+                    title={getPreferredTriple(triple)}
+                    onClick={relationClass}
+                  >
                     <span className="subject">
-                      {`<${lhs[0]}>`}
+                      {`<${triple[0]}>`}
                       &nbsp;
                     </span>
-                    <span>{`<${lhs[1]}>`}</span>
+                    <span>{`<${triple[1]}>`}</span>
                     <span className="focusing">
                       &nbsp;
-                      {`<${focusingURI}>`}
+                      {`<${triple[2]}>`}
                     </span>
                     &nbsp;.
                   </button>
@@ -179,6 +208,7 @@ const ClassRelationsDetail: React.FC<ClassRelationsDetailProps> = (props) => {
       handleClickLeftHandSideClasses,
       intl,
       showLeftHand,
+      getPreferredTriple,
     ]
   )
 

--- a/node/src/ts/visualizer/components/Detail.tsx
+++ b/node/src/ts/visualizer/components/Detail.tsx
@@ -41,10 +41,10 @@ type DetailSectionProps = {
   title: string
   referenceURL: string | null
   uri: string | null
-  classDetail: ClassDetail
+  classes: Classes
 }
 const DetailSection: React.FC<DetailSectionProps> = (props) => {
-  const { sectionType, title, referenceURL, uri, classDetail } = props
+  const { sectionType, title, referenceURL, uri, classes } = props
 
   return (
     <div
@@ -59,7 +59,7 @@ const DetailSection: React.FC<DetailSectionProps> = (props) => {
       <a href={referenceURL || '#'} target="_blank" rel="noopener noreferrer">
         {uri}
       </a>
-      <SubjectDetail classDetail={classDetail} />
+      <SubjectDetail classes={classes} uri={uri} />
     </div>
   )
 }
@@ -80,24 +80,23 @@ const Detail: React.FC<DetailProps> = (props) => {
   const intl = useIntl()
 
   const focusedClassElement = useMemo(() => {
-    const classDetail = classes[focusingURI || '']
     return (
       <FocusClassDetail
-        classDetail={classDetail}
+        classes={classes}
+        uri={focusingURI}
         referenceURL={getReferenceURL(focusingURI)}
       />
     )
   }, [classes, focusingURI, getReferenceURL])
 
   const sameDomainRangeElement = useMemo(() => {
-    const classDetail = classes[domain || '']
     return (
       <DetailSection
         sectionType={SectionType.BOTH}
         title={intl.formatMessage({ id: 'detail.class.subject.or.object' })}
         referenceURL={getReferenceURL(domain)}
         uri={domain}
-        classDetail={classDetail}
+        classes={classes}
       />
     )
   }, [classes, domain, getReferenceURL, intl])
@@ -116,7 +115,7 @@ const Detail: React.FC<DetailProps> = (props) => {
             title={intl.formatMessage({ id: 'detail.class.subject' })}
             referenceURL={getReferenceURL(domain)}
             uri={domain}
-            classDetail={domainClassDetail}
+            classes={classes}
           />
         )}
         {canDrawTriple(domainClassDetail) && (
@@ -129,7 +128,7 @@ const Detail: React.FC<DetailProps> = (props) => {
             fromPropertySelection
             showLeftHand={domain === focusingURI && showLeftHand}
             showRightHand={domain === focusingURI && showRightHand}
-            classDetail={domainClassDetail}
+            classes={classes}
           />
         )}
         {range && (
@@ -138,7 +137,7 @@ const Detail: React.FC<DetailProps> = (props) => {
             title={intl.formatMessage({ id: 'detail.class.object' })}
             referenceURL={getReferenceURL(range)}
             uri={range}
-            classDetail={rangeClassDetail}
+            classes={classes}
           />
         )}
         {canDrawTriple(rangeClassDetail) && (
@@ -151,7 +150,7 @@ const Detail: React.FC<DetailProps> = (props) => {
             fromPropertySelection
             showLeftHand={range === focusingURI && showLeftHand}
             showRightHand={range === focusingURI && showRightHand}
-            classDetail={rangeClassDetail}
+            classes={classes}
           />
         )}
       </>

--- a/node/src/ts/visualizer/components/FocusClassDetail.tsx
+++ b/node/src/ts/visualizer/components/FocusClassDetail.tsx
@@ -1,13 +1,14 @@
 import React from 'react'
 import { useIntl } from 'react-intl'
 import { useSelector } from 'react-redux'
-import { ClassDetail } from '../types/class'
+import { Classes } from '../types/class'
 import { RootState } from '../reducers'
 import ClassRelationsDetail from './ClassRelationsDetail'
 import SubjectDetail from './SubjectDetail'
 
 type FocusClassDetailProps = {
-  classDetail: ClassDetail
+  classes: Classes
+  uri: string | null
   referenceURL: string | null
 }
 
@@ -20,7 +21,7 @@ const selector = ({
 })
 
 const FocusClassDetail: React.FC<FocusClassDetailProps> = (props) => {
-  const { classDetail, referenceURL } = props
+  const { classes, uri, referenceURL } = props
   const { focusingURI, showLeftHand, showRightHand } = useSelector(selector)
   const intl = useIntl()
 
@@ -37,14 +38,14 @@ const FocusClassDetail: React.FC<FocusClassDetailProps> = (props) => {
         <a href={referenceURL || '#'} target="_blank" rel="noopener noreferrer">
           {focusingURI}
         </a>
-        <SubjectDetail classDetail={classDetail} />
+        <SubjectDetail classes={classes} uri={uri} />
       </div>
       <ClassRelationsDetail
         title={intl.formatMessage({ id: 'classRelationsDetail.class.relates' })}
         focusingURI={focusingURI}
         showLeftHand={showLeftHand}
         showRightHand={showRightHand}
-        classDetail={classDetail}
+        classes={classes}
       />
     </div>
   )

--- a/node/src/ts/visualizer/components/SubjectDetail.tsx
+++ b/node/src/ts/visualizer/components/SubjectDetail.tsx
@@ -1,23 +1,23 @@
-import React, { useCallback } from 'react'
+import React, { useMemo } from 'react'
+import { useIntl } from 'react-intl'
 import { useDispatch } from 'react-redux'
 import { SearchAction } from '../actions/search'
-import { ClassDetail } from '../types/class'
+import { Classes } from '../types/class'
+import { getPreferredLabel } from '../utils'
 
 type SubjectDetailProps = {
-  classDetail: ClassDetail | undefined
+  classes: Classes
+  uri: string | null
 }
 
 const SubjectDetail: React.FC<SubjectDetailProps> = (props) => {
-  const { classDetail } = props
+  const { classes, uri } = props
   const dispatch = useDispatch()
+  const intl = useIntl()
 
-  const handleClick = useCallback(
-    (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
-      const uri = e.currentTarget.textContent
-      dispatch(SearchAction.confirmCandidate(uri))
-    },
-    [dispatch]
-  )
+  const classDetail = useMemo(() => {
+    return classes[uri || '']
+  }, [classes, uri])
 
   return (
     <>
@@ -41,14 +41,24 @@ const SubjectDetail: React.FC<SubjectDetailProps> = (props) => {
         <div className="subject">
           <h4>rdfs:subClassOf</h4>
           <ul>
-            {classDetail.subClassOf.map((uri, idx) => (
-              <li key={`component-subjectdetail-list-subclassof-${idx}`}>
-                →&nbsp;
-                <button type="button" className="object" onClick={handleClick}>
-                  {uri}
-                </button>
-              </li>
-            ))}
+            {classDetail.subClassOf.map((superClass, idx) => {
+              const handleClick = () => {
+                dispatch(SearchAction.confirmCandidate(superClass))
+              }
+              return (
+                <li key={`component-subjectdetail-list-subclassof-${idx}`}>
+                  →&nbsp;
+                  <button
+                    type="button"
+                    className="object"
+                    title={getPreferredLabel(superClass, classes, intl.locale)}
+                    onClick={handleClick}
+                  >
+                    {superClass}
+                  </button>
+                </li>
+              )
+            })}
           </ul>
         </div>
       )}

--- a/node/src/ts/visualizer/components/Tooltip.tsx
+++ b/node/src/ts/visualizer/components/Tooltip.tsx
@@ -71,7 +71,7 @@ const Tooltip: React.FC<TooltipProps> = (props) => {
     >
       <h4>URI</h4>
       <p>{uri}</p>
-      <SubjectDetail classDetail={uri ? classes[uri] : undefined} />
+      <SubjectDetail classes={classes} uri={uri} />
       <div className={`arrow ${state.isOnBottom ? 'upward' : 'downward'}`} />
     </div>
   )


### PR DESCRIPTION
45b8dbb
パンくずの右側のの操作が効かない問題の修正

77f8e7a
右ペインのURIまたはトリプルにマウスを当てた際に
URIをrdfs:labelに変換したものを表示するように修正