### PR TITLE
rdfs:labelがあれば、優先的に表示

### DIFF
--- a/node/src/ts/components/Visualize.tsx
+++ b/node/src/ts/components/Visualize.tsx
@@ -28,6 +28,7 @@ const Visualize = (props: Props) => {
       endpoint: '',
       crawl_date: '',
     },
+    labels: {},
   })
 
   React.useEffect(() => {

--- a/node/src/ts/visualizer/components/Breadcrumbs.tsx
+++ b/node/src/ts/visualizer/components/Breadcrumbs.tsx
@@ -5,9 +5,9 @@ import { useDispatch, useSelector } from 'react-redux'
 import { DetailAction } from '../actions/detail'
 import { RootState } from '../reducers'
 import { Classes } from '../types/class'
-import { getPreferredLabel } from '../utils'
 import { flattenParents } from '../utils/node'
 import GraphRepository from '../utils/GraphRepository'
+import { getPreferredLabel } from '../utils/label'
 
 type BreadcrumbsProps = {
   classes: Classes
@@ -56,7 +56,7 @@ const Breadcrumbs: React.FC<BreadcrumbsProps> = (props) => {
             }}
             onKeyDown={() => false}
           >
-            {getPreferredLabel(breadcrumb.data.uri, classes, intl.locale)}
+            {getPreferredLabel(breadcrumb.data.uri, intl.locale, classes)}
           </button>,
           <span key={i}>&gt;</span>,
         ]

--- a/node/src/ts/visualizer/components/ClassRelations.tsx
+++ b/node/src/ts/visualizer/components/ClassRelations.tsx
@@ -1,11 +1,13 @@
 /* eslint-disable camelcase */
 import React, { useCallback, useMemo } from 'react'
+import { useIntl } from 'react-intl'
 import { useDispatch, useSelector } from 'react-redux'
 import { DetailAction } from '../actions/detail'
 import { PropertyAction } from '../actions/property'
 import { RootState } from '../reducers'
 import { ClassRelation as ClassRelationType } from '../types/property'
 import { omitUri } from '../utils'
+import { getPreferredLabel } from '../utils/label'
 
 type ClassRelationProps = {
   relation: ClassRelationType
@@ -22,6 +24,7 @@ const ClassRelation: React.FC<ClassRelationProps> = (props) => {
     propertyClass,
   } = props
   const dispatch = useDispatch()
+  const intl = useIntl()
 
   const handleClick = useCallback(
     (e: React.MouseEvent<HTMLLIElement, MouseEvent>) => {
@@ -77,7 +80,9 @@ const ClassRelation: React.FC<ClassRelationProps> = (props) => {
           >
             <span className="icon subject">S</span>
             <span data-tip={subjectTip} className={`text ${domainClassName}`}>
-              {subject_class ? omitUri(subject_class) : 'resource'}
+              {subject_class
+                ? getPreferredLabel(subject_class, intl.locale)
+                : 'resource'}
             </span>
           </span>
         )}
@@ -90,10 +95,10 @@ const ClassRelation: React.FC<ClassRelationProps> = (props) => {
             >
               {(() => {
                 if (object_class) {
-                  return omitUri(object_class)
+                  return getPreferredLabel(object_class, intl.locale)
                 }
                 if (object_datatype) {
-                  return omitUri(object_datatype)
+                  return getPreferredLabel(object_datatype, intl.locale)
                 }
                 return 'resource'
               })()}

--- a/node/src/ts/visualizer/components/ClassRelationsDetail.tsx
+++ b/node/src/ts/visualizer/components/ClassRelationsDetail.tsx
@@ -4,8 +4,8 @@ import { useDispatch, useSelector } from 'react-redux'
 import { DetailAction } from '../actions/detail'
 import { RootState } from '../reducers'
 import { Classes } from '../types/class'
-import { getPreferredLabel } from '../utils'
 import GraphRepository from '../utils/GraphRepository'
+import { getPreferredLabel } from '../utils/label'
 
 type ClassRelationsDetailProps = {
   title: string
@@ -42,10 +42,10 @@ const ClassRelationsDetail: React.FC<ClassRelationsDetailProps> = (props) => {
       if (triple.length < 3) {
         return '<><><>'
       }
-      const subject = getPreferredLabel(triple[0], classes, intl.locale)
-      const predicate = getPreferredLabel(triple[1], classes, intl.locale)
+      const subject = getPreferredLabel(triple[0], intl.locale, classes)
+      const predicate = getPreferredLabel(triple[1], intl.locale, classes)
       const object =
-        getPreferredLabel(triple[2], classes, intl.locale) ??
+        getPreferredLabel(triple[2], intl.locale, classes) ??
         intl.formatMessage({ id: 'detail.no.object' })
       return `<${subject}><${predicate}><${object}>`
     },

--- a/node/src/ts/visualizer/components/ClassStructure.tsx
+++ b/node/src/ts/visualizer/components/ClassStructure.tsx
@@ -20,6 +20,7 @@ import {
   makeQueryWhenRightClickArrow,
   makeQueryWhenRightClickClass,
 } from '../utils/sparql'
+import { getPreferredLabel } from '../utils/label'
 
 export const CIRCLE_CONTEXT_MENU_ID = 'circle-context-menu-id'
 
@@ -130,7 +131,10 @@ function makeArrowMouseover(
     const predicateMessage = intl.formatMessage({
       id: 'classStructure.text.predicate',
     })
-    GraphRepository.addPopup(x, y, getUris(d), predicateMessage)
+    const predicateLabels = getUris(d).map((uri) =>
+      getPreferredLabel(uri, intl.locale)
+    )
+    GraphRepository.addPopup(x, y, predicateLabels, predicateMessage)
 
     GraphRepository.updatePosition()
   }

--- a/node/src/ts/visualizer/components/Property.tsx
+++ b/node/src/ts/visualizer/components/Property.tsx
@@ -1,11 +1,13 @@
 /* eslint-disable camelcase */
 import React, { useCallback, useMemo } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
+import { useIntl } from 'react-intl'
 import { PropertyAction } from '../actions/property'
 import { RootState } from '../reducers'
 import { Property as PropertyType } from '../types/property'
 import ClassRelations from './ClassRelations'
 import { omitUri } from '../utils'
+import { getPreferredLabel } from '../utils/label'
 
 type PropertyProps = {
   property: PropertyType
@@ -26,6 +28,7 @@ const Property: React.FC<PropertyProps> = (props) => {
   } = props
   const { openPropertyIndexes, referenceProperties } = useSelector(selector)
   const dispatch = useDispatch()
+  const intl = useIntl()
 
   const handleClick = useCallback(() => {
     if (openPropertyIndexes[index]) {
@@ -53,7 +56,7 @@ const Property: React.FC<PropertyProps> = (props) => {
       onKeyDown={() => false}
     >
       <span className="property" data-tip={isOmittingUri ? uri : undefined}>
-        {omitUri(uri)}
+        {getPreferredLabel(uri, intl.locale)}
       </span>
       <span className="triple-count">{triples}</span>
       {class_relations.length > 0 && <span className="open-toggle" />}

--- a/node/src/ts/visualizer/components/SubjectDetail.tsx
+++ b/node/src/ts/visualizer/components/SubjectDetail.tsx
@@ -3,7 +3,7 @@ import { useIntl } from 'react-intl'
 import { useDispatch } from 'react-redux'
 import { SearchAction } from '../actions/search'
 import { Classes } from '../types/class'
-import { getPreferredLabel } from '../utils'
+import { getLabels, getPreferredLabel } from '../utils/label'
 
 type SubjectDetailProps = {
   classes: Classes
@@ -14,24 +14,29 @@ const SubjectDetail: React.FC<SubjectDetailProps> = (props) => {
   const { classes, uri } = props
   const dispatch = useDispatch()
   const intl = useIntl()
+  const labels = getLabels()
 
   const classDetail = useMemo(() => {
     return classes[uri || '']
   }, [classes, uri])
 
+  const label = useMemo(() => {
+    return labels?.[uri || ''] ?? classDetail?.label
+  }, [classes, uri])
+
   return (
     <>
-      {classDetail?.label && (
+      {label && (
         <div className="subject">
           <h4>rdfs:label</h4>
           <ul>
-            {Object.keys(classDetail.label)
+            {Object.keys(label)
               .sort()
               .reverse()
               .map((lang, idx) => (
                 <li key={`component-subjectdetail-list-label-${idx}`}>
                   →&nbsp;
-                  <span className="object">{classDetail.label?.[lang]}</span>
+                  <span className="object">{label[lang]}</span>
                 </li>
               ))}
           </ul>
@@ -51,7 +56,7 @@ const SubjectDetail: React.FC<SubjectDetailProps> = (props) => {
                   <button
                     type="button"
                     className="object"
-                    title={getPreferredLabel(superClass, classes, intl.locale)}
+                    title={getPreferredLabel(superClass, intl.locale, classes)}
                     onClick={handleClick}
                   >
                     {superClass}

--- a/node/src/ts/visualizer/components/Tooltip.tsx
+++ b/node/src/ts/visualizer/components/Tooltip.tsx
@@ -4,7 +4,7 @@ import { useIntl } from 'react-intl'
 import { RootState } from '../reducers'
 import { Classes } from '../types/class'
 import SubjectDetail from './SubjectDetail'
-import { getPreferredLabel } from '../utils'
+import { getPreferredLabel } from '../utils/label'
 
 type TooltipProps = {
   classes: Classes
@@ -93,7 +93,7 @@ const Tooltip: React.FC<TooltipProps> = (props) => {
 
     const detail = classes[uri]
     const entities = detail?.entities
-    const preferredLabel = getPreferredLabel(uri, classes, intl.locale)
+    const preferredLabel = getPreferredLabel(uri, intl.locale, classes)
     return (
       <div
         ref={tooltipRef}

--- a/node/src/ts/visualizer/components/Tree.tsx
+++ b/node/src/ts/visualizer/components/Tree.tsx
@@ -16,9 +16,9 @@ import TreeRepository, {
   shouldShowDisplayButton,
 } from '../utils/TreeRepository'
 import { RootState } from '../reducers'
-import { getPreferredLabel } from '../utils'
 import { DetailAction } from '../actions/detail'
 import { DEFAULT_MAX_DEPTH, Depth, Margin } from '../constants/Tree'
+import { getPreferredLabel } from '../utils/label'
 
 type TreeProps = {
   nodes: NodeType[]
@@ -468,7 +468,7 @@ export const Tree: React.FC<TreeProps> = (props) => {
   )
 
   const preferredLabel = React.useMemo(
-    () => getPreferredLabel(focusingURI || '', classes, intl.locale),
+    () => getPreferredLabel(focusingURI || '', intl.locale, classes),
     [classes, focusingURI, intl.locale]
   )
   const baseElement = React.useMemo(

--- a/node/src/ts/visualizer/index.tsx
+++ b/node/src/ts/visualizer/index.tsx
@@ -36,12 +36,14 @@ import { RootState } from './reducers'
 import { FilterAction } from './actions/filter'
 import { flattenStructure } from './utils/node'
 import { AppState, Content } from './types'
+import { setLabels } from './utils/label'
 
 const initialAppState: AppState = {
   structure: [],
   classes: {},
   properties: [],
   prefixes: {},
+  labels: {},
 }
 
 const filterStateDestructive = (
@@ -137,6 +139,7 @@ const App: React.FC<AppProps> = (props) => {
       classes: content.classes,
       properties: content.properties,
       prefixes: content.prefixes,
+      labels: content.labels,
     }
 
     if (isEmptyState(nextState) || !isEmptyState(rawState)) {
@@ -201,7 +204,8 @@ const App: React.FC<AppProps> = (props) => {
     setState(nextState)
   }, [rawState, lowerLimitOfClassEntities])
 
-  const { structure, classes, properties, prefixes } = state
+  const { structure, classes, properties, prefixes, labels } = state
+  setLabels(labels)
   return (
     <div id="main">
       <PropertyList properties={properties} />

--- a/node/src/ts/visualizer/types/class.ts
+++ b/node/src/ts/visualizer/types/class.ts
@@ -1,6 +1,4 @@
-type Label = {
-  [key: string]: string // key: language, value: class
-}
+import { Label } from './label'
 
 export type ClassDetail = {
   entities?: number

--- a/node/src/ts/visualizer/types/index.ts
+++ b/node/src/ts/visualizer/types/index.ts
@@ -1,5 +1,6 @@
 /* eslint-disable camelcase */
 import { Classes } from './class'
+import { Labels } from './label'
 import { Metadata } from './metadata'
 import { Prefixes } from './prefix'
 import { Property } from './property'
@@ -21,6 +22,7 @@ export type AppState = {
   classes: Classes
   properties: Property[]
   prefixes: Prefixes
+  labels: Labels
 }
 
 export type Content = {
@@ -29,4 +31,5 @@ export type Content = {
   properties: Property[]
   prefixes: Prefixes
   meta_data: Metadata
+  labels: Labels
 }

--- a/node/src/ts/visualizer/types/label.ts
+++ b/node/src/ts/visualizer/types/label.ts
@@ -1,0 +1,7 @@
+export type Labels = {
+  [key: string]: Label // key: uri
+}
+
+export type Label = {
+  [key: string]: string // key: language, value: class
+}

--- a/node/src/ts/visualizer/utils/GraphRepository.ts
+++ b/node/src/ts/visualizer/utils/GraphRepository.ts
@@ -342,13 +342,13 @@ class GraphRepository {
 
   x(x: number) {
     const ret = (this.XLinear?.(x) ?? 0) + this.coordinate[0]
-    if (isNaN(ret)) return this.coordinate[0]
+    if (Number.isNaN(ret)) return this.coordinate[0]
     return ret
   }
 
   y(y: number) {
     const ret = (this.YLinear?.(y) ?? 0) + this.coordinate[1]
-    if (isNaN(ret)) return this.coordinate[1]
+    if (Number.isNaN(ret)) return this.coordinate[1]
     return ret
   }
 

--- a/node/src/ts/visualizer/utils/GraphRepository.ts
+++ b/node/src/ts/visualizer/utils/GraphRepository.ts
@@ -18,8 +18,9 @@ import {
   getNodeUris,
   nodeKeyFn,
 } from './node'
-import { getPreferredLabel, isIE11 } from '.'
+import { isIE11 } from '.'
 import SVGElementsAccessor from './SVGElementsAccessor'
+import { getPreferredLabel } from './label'
 
 export type Point = { x: number; y: number }
 
@@ -1066,7 +1067,7 @@ class GraphRepository {
 
     texts
       ?.append('tspan')
-      .text((d) => getPreferredLabel(d.data.uri, classes, locale))
+      .text((d) => getPreferredLabel(d.data.uri, locale, classes))
       .attr('x', 0)
       .each((d, i, g) => {
         textBeforeEdgePolyfill(g[i], d.data.isLabelOnTop)

--- a/node/src/ts/visualizer/utils/TreeRepository.ts
+++ b/node/src/ts/visualizer/utils/TreeRepository.ts
@@ -13,7 +13,7 @@ import {
 import { Classes } from '../types/class'
 import { TreeState } from '../components/Tree'
 import { NodeType, SVGEventHandlerType } from './GraphRepository'
-import { getPreferredLabel, isIE11 } from '.'
+import { isIE11 } from '.'
 import {
   calcDepthDiff,
   getNodeUris,
@@ -22,6 +22,7 @@ import {
   isLinealChildren,
   getLinealAscendantNodes,
 } from './node'
+import { getPreferredLabel } from './label'
 
 export const shouldShowDisplayButton = (
   node: NodeType,
@@ -710,7 +711,7 @@ class TreeRepository {
       .attr('class', 'top')
       .append('xhtml')
       .append('p')
-      .text((d) => getPreferredLabel(d.data.uri, classes, intl.locale))
+      .text((d) => getPreferredLabel(d.data.uri, intl.locale, classes))
       .each((d, i, g) => {
         if (!d) return // prevention: unused parameter error(datum)
         const textSize = g[i]?.getBoundingClientRect()

--- a/node/src/ts/visualizer/utils/index.ts
+++ b/node/src/ts/visualizer/utils/index.ts
@@ -1,6 +1,5 @@
 import { useLocation } from 'react-router-dom'
 import locales from '../locales'
-import { Classes } from '../types/class'
 
 export const omitUri = (uri: string) => {
   if (!uri) return uri
@@ -20,20 +19,6 @@ export const omitUri = (uri: string) => {
   }
 
   return uri
-}
-
-export const getPreferredLabel = (
-  uri: string,
-  classes: Classes,
-  locale: string
-): string => {
-  const labels = classes[uri]?.label
-  if (!labels) {
-    return omitUri(uri)
-  }
-
-  const label = labels[locale] ?? labels.en ?? labels[''] ?? undefined
-  return label ?? omitUri(uri)
 }
 
 export const getLocaleShortString = (): string => {

--- a/node/src/ts/visualizer/utils/label.ts
+++ b/node/src/ts/visualizer/utils/label.ts
@@ -1,0 +1,27 @@
+import { omitUri } from '.'
+import { Classes } from '../types/class'
+import { Labels } from '../types/label'
+
+let labels: Labels | undefined = {}
+
+export const setLabels = (newLabels: Labels) => {
+  labels = newLabels
+}
+
+export const getLabels = () => {
+  return labels
+}
+
+export const getPreferredLabel = (
+  uri: string,
+  locale: string,
+  classes?: Classes
+): string => {
+  const u = omitUri(uri)
+  const label = labels?.[u] ?? classes?.[u]?.label
+  if (!label) {
+    return u
+  }
+  const l = label[locale] ?? label.en ?? label[''] ?? undefined
+  return l ?? u
+}


### PR DESCRIPTION
### 問題
- rdfs:labelが設定されているにもかかわらず、表示されない

### 原因
- umakaviewerではclassesのlabelは取得できているが、property（述語）のlabelは取得していなかった。

### やったこと
- umakaparserを修正してlabelを取ってくるようにした
  - https://github.com/dbcls/umakaparser/pull/46
- `Labels`typeを追加
- utilsにlabel変数を追加
- getterとsetterの作成
- getPreferredLabelのリファクタ

### screenshots
|Before|After|
|-|-|
|![image](https://github.com/user-attachments/assets/3832a81e-a3ea-49cc-bba5-ea35786f946d)|![after](https://github.com/user-attachments/assets/88cbc49a-0907-4148-ba2d-08ff9a728a42)|
