### PR TITLE
左ペインのツールチップを表示

### DIFF
--- a/node/src/ts/visualizer/components/ClassRelations.tsx
+++ b/node/src/ts/visualizer/components/ClassRelations.tsx
@@ -6,7 +6,6 @@ import { DetailAction } from '../actions/detail'
 import { PropertyAction } from '../actions/property'
 import { RootState } from '../reducers'
 import { ClassRelation as ClassRelationType } from '../types/property'
-import { omitUri } from '../utils'
 import { getPreferredLabel } from '../utils/label'
 
 type ClassRelationProps = {
@@ -51,15 +50,19 @@ const ClassRelation: React.FC<ClassRelationProps> = (props) => {
     if (!subject_class) {
       return undefined
     }
-    return subject_class !== omitUri(subject_class) ? subject_class : undefined
+    return subject_class !== getPreferredLabel(subject_class, intl.locale)
+      ? subject_class
+      : undefined
   }, [subject_class])
 
   const objectTip = useMemo(() => {
     if (object_class) {
-      return object_class !== omitUri(object_class) ? object_class : undefined
+      return object_class !== getPreferredLabel(object_class, intl.locale)
+        ? object_class
+        : undefined
     }
     if (object_datatype) {
-      return object_datatype !== omitUri(object_datatype)
+      return object_datatype !== getPreferredLabel(object_datatype, intl.locale)
         ? object_datatype
         : undefined
     }


### PR DESCRIPTION
https://github.com/dbcls/umakaviewer/pull/173
前回の修正↑で左ペインにラベルがあれば、ラベルを表示することにした

ラベルが表示されている場合元のURIを知るすべがないので、以下の機能を追加
- ツールチップにはURIを常に表示させる
- ただしデータと表示内容が同じだった場合はツールチップを表示しない

|before|after|
|-|-|
|![before](https://github.com/user-attachments/assets/4d354b39-dbf4-4ddb-b7a0-af6d1a574b8b)|![after](https://github.com/user-attachments/assets/50e8cdc4-6e7e-45f8-bbc1-f8c9571016b8)|